### PR TITLE
Update 4_process_merged_date.R.  Line 19 predictors_drop Removal

### DIFF
--- a/scripts/data_processing/4_process_merged_data.R
+++ b/scripts/data_processing/4_process_merged_data.R
@@ -16,7 +16,7 @@ predictors <- names(select(eof, rain:ARFdays14, sin_sdate:snwd_diff, days_since_
                            ant_dis_1day_max:ant_dis_14day_max, frozen))
 
 # drop site-specific predictors that shouldn't be in mod
-predictors <- predictors[-which(predictors %in% predictors_drop)]
+predictors <- predictors[!(predictors %in% predictors_drop)]
                     
 # set responses and set cleaner name to plot for responses
 if (length(concentrations) > 1) {


### PR DESCRIPTION
For some reason the previous indexing code was removing all the values from the predictors list instead of just removing the list of desired predictors to drop. Wrote the indexing in a slightly different way that seems to work.