### PR TITLE
Update 0_before_after_datmod_prep.R Lines 6, 7, and 30 Dealing with I…

### DIFF
--- a/scripts/data_analysis/0_before_after_datmod_prep.R
+++ b/scripts/data_analysis/0_before_after_datmod_prep.R
@@ -2,6 +2,12 @@
 temp.filename <- paste0(site, '_mod_dat.csv')
 dat <- read.csv(file.path('data_cached', temp.filename))
 
+# change infinite values to 365, representing a full year since application
+dat<-do.call(data.frame,lapply(dat, function(x) replace(x, is.infinite(x),365)))
+                               
+# change 'NaN' values to NA to omit during data processing
+dat<-do.call(data.frame,lapply(dat, function(x) replace(x, "NaN",NA)))
+                               
 # define predictors
 load('data_cached/modvars.Rdata')
 dat.mod <- dat[,predictors]
@@ -20,6 +26,9 @@ drop.predictors <- caret::findCorrelation(predictors.cor, cutoff = 0.95, verbose
 
 predictors.keep <- c(names.cor[-drop.predictors], 'frozen')
 
+# Change all 0 values to 0.0000001, so we can take the log10 of those vlaues
+dat.mod[dat.mod==0] <- 0.0000001
+                               
 # log transform response vars
 dat.mod[,responses] <- log10(dat.mod[,responses])
 sums <- colSums(dat.mod[,responses])


### PR DESCRIPTION
…nf and NA Values

line 6: In the dat variable there were some Inf values under days since fertilizer application. This function will change these values to 365, indicating a year since application. There may be a better way to deal with the Inf value, but for now a value of 365 has been put in place of Inf. 

Line 7: Carets findCorrelation function will not accept NAs or character values. A character value of 'NaN' was introduced at some point in the code. This function removes these 'NaN' characters and replaces them with true NA. These NA values can then be removed. 

line 30: 0 values are introduced at some point in the code. We cannot take the log10 value of 0, so all zeros were replaced by a very small number (0.0000001).